### PR TITLE
Updated env sample with names of required vars

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,3 +1,14 @@
 APP_ENV=development
 LBHPACKAGESTOKEN=<token>
 DOCKERFILE_DIR=default
+
+# Database
+CONNECTION_STRING=
+DB_HOST=
+DB_PORT=
+DB_USERNAME=
+DB_PASSWORD=
+
+# Local Database
+DynamoDb_LocalMode=
+DynamoDb_LocalServiceUrl=

--- a/.env.sample
+++ b/.env.sample
@@ -8,7 +8,3 @@ DB_HOST=
 DB_PORT=
 DB_USERNAME=
 DB_PASSWORD=
-
-# Local Database
-DynamoDb_LocalMode=
-DynamoDb_LocalServiceUrl=


### PR DESCRIPTION
This is because more environment variables were required than in the original env sample - these have been added without the values to the sample.