### PR TITLE
Upgrade API to .NET 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ executors:
       - image: "hashicorp/terraform:light"
   docker-dotnet:
     docker:
-      - image: mcr.microsoft.com/dotnet/sdk:6.0
+      - image: mcr.microsoft.com/dotnet/sdk:8.0
 
 references:
   workspace_root: &workspace_root "~"

--- a/AcademyApi.Tests/AcademyApi.Tests.csproj
+++ b/AcademyApi.Tests/AcademyApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
@@ -16,13 +16,14 @@
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="Hackney.Core.Testing.DynamoDb" Version="1.57.0" />
     <PackageReference Include="Hackney.Core.Testing.Shared" Version="1.54.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="Bogus" Version="25.0.4" />
     <PackageReference Include="Moq" Version="4.16.1" />

--- a/AcademyApi.Tests/Dockerfile
+++ b/AcademyApi.Tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # disable microsoft telematry
 ENV DOTNET_CLI_TELEMETRY_OPTOUT='true'

--- a/AcademyApi.Tests/V1/Controllers/BaseControllerTests.cs
+++ b/AcademyApi.Tests/V1/Controllers/BaseControllerTests.cs
@@ -41,7 +41,7 @@ namespace AcademyApi.Tests.V1.Controllers
         public void GetCorrelationShouldReturnCorrelationIdWhenExists()
         {
             // Arrange
-            _stubHttpContext.Request.Headers.Add(HeaderConstants.CorrelationId, "123");
+            _stubHttpContext.Request.Headers.Append(HeaderConstants.CorrelationId, "123");
 
             // Act
             var result = _sut.GetCorrelationId();

--- a/AcademyApi/AcademyApi.csproj
+++ b/AcademyApi/AcademyApi.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>AcademyApi</RootNamespace>
   </PropertyGroup>
     <PropertyGroup>
@@ -30,15 +30,16 @@
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="6.0.0">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.4.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="7.2.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="3.1.3" />
   </ItemGroup>
 

--- a/AcademyApi/Dockerfile
+++ b/AcademyApi/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0
+FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 ARG LBHPACKAGESTOKEN
 ENV LBHPACKAGESTOKEN=$LBHPACKAGESTOKEN

--- a/AcademyApi/build.cmd
+++ b/AcademyApi/build.cmd
@@ -1,2 +1,2 @@
 dotnet restore
-dotnet lambda package --configuration release --framework netcoreapp3.1 --output-package bin/release/netcoreapp3.1/academy-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package bin/release/net8.0/academy-api.zip

--- a/AcademyApi/build.sh
+++ b/AcademyApi/build.sh
@@ -18,4 +18,4 @@ then
 fi
 
 dotnet restore
-dotnet lambda package --configuration release --framework net6.0 --output-package ./bin/release/net6.0/academy-api.zip
+dotnet lambda package --configuration release --framework net8.0 --output-package ./bin/release/net8.0/academy-api.zip

--- a/AcademyApi/serverless.yml
+++ b/AcademyApi/serverless.yml
@@ -1,7 +1,7 @@
 service: academy-api
 provider:
   name: aws
-  runtime: dotnet6
+  runtime: dotnet8
   memorySize: 2048
   tracing:
     lambda: true
@@ -16,7 +16,7 @@ provider:
 
 package:
   # TODO: Rename zipfile in build.sh and build.cmd to match this
-  artifact: ./bin/release/net6.0/academy-api.zip
+  artifact: ./bin/release/net8.0/academy-api.zip
 
 functions:
   academyApi:

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update && \
     apt-get update && \
     # Install SQL Server from apt
     apt-get install -y mssql-server && \
+    # Install optional packages
+    apt-get install -y mssql-server-ha && \
+    apt-get install -y mssql-server-fts && \
     # Cleanup the Dockerfile
     apt-get clean && \
     rm -rf /var/lib/apt/lists

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -10,10 +10,10 @@ USER root
 RUN ACCEPT_EULA=Y apt-get update && apt-get install -y mssql-tools18 unixodbc-dev
 USER mssql
 
-RUN /opt/mssql/bin/sqlservr & sleep 90 \
+RUN /opt/mssql/bin/sqlservr & sleep 20 \
     && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
-    -Q "create database core;" \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \
+    -Q "create database core;" --TrustServerCertificate \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core --TrustServerCertificate \
     -e -i ./database/schema.sql
 
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -3,25 +3,28 @@ EXPOSE 1433
 
 COPY . .
 
-ENV MSSQL_SA_PASSWORD="MyP@w0rd"
-ENV ACCEPT_EULA="Y"
+ENV ACCEPT_EULA=Y
+ENV MSSQL_SA_PASSWORD=MyP@w0rd
 ENV PATH="$PATH:/opt/mssql-tools/bin"
 
-# Switch to root to install dependencies
-USER root
+# # Switch to root to install dependencies
+# USER root
 
 # Install dependencies and the SQL Server tools
 RUN apt-get update && \
-    apt-get install -y curl apt-transport-https gnupg && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
-    echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get install -yq curl apt-transport-https && \
+    # Get official Microsoft repository configuration
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list | tee /etc/apt/sources.list.d/mssql-server.list && \
     apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools && \
+    # Install SQL Server from apt
+    apt-get install -y mssql-server && \
+    # Cleanup the Dockerfile
     apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists
 
-# Switch back to the default user
-USER mssql
+# # Switch back to the default user
+# USER mssql
 
 # Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -3,19 +3,18 @@ EXPOSE 1433
 
 COPY . .
 
-ENV SA_PASSWORD "MyP@w0rd"
+ENV MSSQL_SA_PASSWORD "MyP@w0rd"
 ENV ACCEPT_EULA "Y"
-ENV PATH "$PATH:/opt/mssql-tools/bin"
+# ENV PATH "$PATH:/opt/mssql-tools/bin"
 
-# Install SQL Server tools
-RUN apt-get update && \
-    apt-get install -y curl apt-transport-https && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-    apt-get update && \
-    ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+# # Install SQL Server tools
+# RUN apt-get update && \
+#     apt-get install -y curl apt-transport-https && \
+#     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+#     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+#     apt-get update && \
+#     apt-get install -y msodbcsql17 mssql-tools && \
+    # apt-get clean
 
 # Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -1,4 +1,4 @@
-FROM  mcr.microsoft.com/mssql/server
+FROM mcr.microsoft.com/mssql/server
 EXPOSE 1433
 
 COPY . .
@@ -10,13 +10,13 @@ ENV PATH="$PATH:/opt/mssql-tools/bin"
 # Switch to root to install dependencies
 USER root
 
-# Install SQL Server tools
+# Install dependencies and the SQL Server tools
 RUN apt-get update && \
-    apt-get install -y curl apt-transport-https && \
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get install -y curl apt-transport-https gnupg && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
+    echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/22.04/prod jammy main" > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && \
-    apt-get install -y msodbcsql17 mssql-tools && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -3,17 +3,13 @@ EXPOSE 1433
 
 COPY . .
 
-ENV MSSQL_SA_PASSWORD "MyP@w0rd"
+ENV SA_PASSWORD "MyP@w0rd"
 ENV ACCEPT_EULA "Y"
 
-USER root
-RUN ACCEPT_EULA=Y apt-get update && apt-get install -y mssql-tools18 unixodbc-dev
-USER mssql
-
 RUN /opt/mssql/bin/sqlservr & sleep 20 \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master -C \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d master -C \
     -Q "create database core;" \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core -C \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d core -C \
     -e -i ./database/schema.sql
 
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -4,13 +4,25 @@ EXPOSE 1433
 COPY . .
 
 ENV SA_PASSWORD "MyP@w0rd"
-
 ENV ACCEPT_EULA "Y"
+ENV PATH "$PATH:/opt/mssql-tools/bin"
 
+# Install SQL Server tools
+RUN apt-get update && \
+    apt-get install -y curl apt-transport-https && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    ACCEPT_EULA=Y apt-get install -y msodbcsql17 mssql-tools && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \
     && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d master \
     -Q "create database core;" \
     && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d core \
     -e -i ./database/schema.sql
 
+# Start SQL Server
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -4,10 +4,11 @@ EXPOSE 1433
 COPY . .
 
 ENV MSSQL_SA_PASSWORD "MyP@w0rd"
-
 ENV ACCEPT_EULA "Y"
 
-RUN sudo ACCEPT_EULA=Y apt-get install mssql-tools18 unixodbc-dev
+USER root
+RUN ACCEPT_EULA=Y apt-get update && apt-get install -y mssql-tools18 unixodbc-dev
+USER mssql
 
 RUN /opt/mssql/bin/sqlservr & sleep 90 \
     && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -11,9 +11,9 @@ RUN ACCEPT_EULA=Y apt-get update && apt-get install -y mssql-tools18 unixodbc-de
 USER mssql
 
 RUN /opt/mssql/bin/sqlservr & sleep 20 \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master -C TrustServerCertificate=True \
     -Q "create database core;" \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core -C TrustServerCertificate=True \
     -e -i ./database/schema.sql
 
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -11,9 +11,9 @@ RUN ACCEPT_EULA=Y apt-get update && apt-get install -y mssql-tools18 unixodbc-de
 USER mssql
 
 RUN /opt/mssql/bin/sqlservr & sleep 90 \
-    && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
     -Q "create database core;" \
-    && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \
     -e -i ./database/schema.sql
 
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -3,38 +3,14 @@ EXPOSE 1433
 
 COPY . .
 
-ENV ACCEPT_EULA=Y
-ENV MSSQL_SA_PASSWORD=MyP@w0rd
-ENV PATH="$PATH:/opt/mssql-tools/bin"
+ENV MSSQL_SA_PASSWORD "MyP@w0rd"
 
-# Switch to root to install dependencies
-USER root
+ENV ACCEPT_EULA "Y"
 
-# Install dependencies and the SQL Server tools
-RUN apt-get update && \
-    apt-get install -yq curl apt-transport-https && \
-    # Get official Microsoft repository configuration
-    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-    curl https://packages.microsoft.com/config/ubuntu/16.04/mssql-server-2017.list | tee /etc/apt/sources.list.d/mssql-server.list && \
-    apt-get update && \
-    # Install SQL Server from apt
-    apt-get install -y mssql-server && \
-    # Install optional packages
-    apt-get install -y mssql-server-ha && \
-    apt-get install -y mssql-server-fts && \
-    # Cleanup the Dockerfile
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists
-
-# Switch back to the default user
-USER mssql
-
-# Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \
-    && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d master \
+    && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
     -Q "create database core;" \
-    && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${SA_PASSWORD} -d core \
+    && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \
     -e -i ./database/schema.sql
 
-# Start SQL Server
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -5,16 +5,16 @@ COPY . .
 
 ENV MSSQL_SA_PASSWORD "MyP@w0rd"
 ENV ACCEPT_EULA "Y"
-# ENV PATH "$PATH:/opt/mssql-tools/bin"
+ENV PATH "$PATH:/opt/mssql-tools/bin"
 
-# # Install SQL Server tools
-# RUN apt-get update && \
-#     apt-get install -y curl apt-transport-https && \
-#     curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
-#     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
-#     apt-get update && \
-#     apt-get install -y msodbcsql17 mssql-tools && \
-    # apt-get clean
+# Install SQL Server tools
+RUN apt-get update && \
+    apt-get install -y curl apt-transport-https && \
+    curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - && \
+    curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
+    apt-get update && \
+    apt-get install -y msodbcsql17 mssql-tools && \
+    apt-get clean
 
 # Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -12,8 +12,8 @@ USER mssql
 
 RUN /opt/mssql/bin/sqlservr & sleep 20 \
     && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
-    -Q "create database core;" --TrustServerCertificate \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core --TrustServerCertificate \
+    -Q "create database core;" \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \
     -e -i ./database/schema.sql
 
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -11,9 +11,9 @@ RUN ACCEPT_EULA=Y apt-get update && apt-get install -y mssql-tools18 unixodbc-de
 USER mssql
 
 RUN /opt/mssql/bin/sqlservr & sleep 20 \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master -C TrustServerCertificate=True \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master -C \
     -Q "create database core;" \
-    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core -C TrustServerCertificate=True \
+    && /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core -C \
     -e -i ./database/schema.sql
 
 CMD /opt/mssql/bin/sqlservr

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -3,9 +3,12 @@ EXPOSE 1433
 
 COPY . .
 
-ENV MSSQL_SA_PASSWORD "MyP@w0rd"
-ENV ACCEPT_EULA "Y"
-ENV PATH "$PATH:/opt/mssql-tools/bin"
+ENV MSSQL_SA_PASSWORD="MyP@w0rd"
+ENV ACCEPT_EULA="Y"
+ENV PATH="$PATH:/opt/mssql-tools/bin"
+
+# Switch to root to install dependencies
+USER root
 
 # Install SQL Server tools
 RUN apt-get update && \
@@ -14,8 +17,11 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && \
     apt-get install -y msodbcsql17 mssql-tools && \
-    sudo apt-get clean && \
-    sudo rm -rf /var/lib/apt/lists
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Switch back to the default user
+USER mssql
 
 # Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -7,7 +7,7 @@ ENV MSSQL_SA_PASSWORD "MyP@w0rd"
 
 ENV ACCEPT_EULA "Y"
 
-RUN /opt/mssql/bin/sqlservr & sleep 20 \
+RUN /opt/mssql/bin/sqlservr & sleep 90 \
     && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
     -Q "create database core;" \
     && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d core \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -7,8 +7,8 @@ ENV ACCEPT_EULA=Y
 ENV MSSQL_SA_PASSWORD=MyP@w0rd
 ENV PATH="$PATH:/opt/mssql-tools/bin"
 
-# # Switch to root to install dependencies
-# USER root
+# Switch to root to install dependencies
+USER root
 
 # Install dependencies and the SQL Server tools
 RUN apt-get update && \
@@ -23,8 +23,8 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists
 
-# # Switch back to the default user
-# USER mssql
+# Switch back to the default user
+USER mssql
 
 # Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -7,6 +7,8 @@ ENV MSSQL_SA_PASSWORD "MyP@w0rd"
 
 ENV ACCEPT_EULA "Y"
 
+RUN sudo ACCEPT_EULA=Y apt-get install mssql-tools18 unixodbc-dev
+
 RUN /opt/mssql/bin/sqlservr & sleep 90 \
     && /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P ${MSSQL_SA_PASSWORD} -d master \
     -Q "create database core;" \

--- a/database/default/Dockerfile
+++ b/database/default/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
     curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > /etc/apt/sources.list.d/mssql-release.list && \
     apt-get update && \
     apt-get install -y msodbcsql17 mssql-tools && \
-    apt-get clean
+    sudo apt-get clean && \
+    sudo rm -rf /var/lib/apt/lists
 
 # Initialize database
 RUN /opt/mssql/bin/sqlservr & sleep 20 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      - CONNECTION_STRING=Server=test-database,1433;Database=core;User Id=sa;Password=MyP@w0rd;TrustServerCertificate=yes;
+      - CONNECTION_STRING=Server=test-database,1433;Database=core;User Id=sa;Password=MyP@w0rd;
     links:
       - test-database
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.2"
 
 services:
   academy-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      - CONNECTION_STRING=Server=test-database,1433;Database=core;User Id=sa;Password=MyP@w0rd;
+      - CONNECTION_STRING=Server=test-database,1433;Database=core;User Id=sa;Password=MyP@w0rd;TrustServerCertificate=yes;
     links:
       - test-database
 


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SSI-295

## Describe this PR

Update API to .NET 8. Also, resolve issues with the test database docker image (see below):

**From https://mcr.microsoft.com/artifact/mar/mssql/server/about:**

> Note: Starting with SQL Server 2022 (16.x) CU 14 and SQL Server 2019 (15.x) CU 28, container images include the [new mssql-tools18](https://review.learn.microsoft.com/sql/linux/sql-server-linux-setup-tools?view=sql-server-ver16#install-tools-on-linux) package. The previous directory /opt/mssql-tools/bin is being phased out. The new directory for Microsoft ODBC 18 tools is /opt/mssql-tools18/bin, aligning with the latest tools offering. For more information about changes and security enhancements, see [ODBC Driver 18.0 for SQL Server Released](https://techcommunity.microsoft.com/t5/sql-server-blog/odbc-driver-18-0-for-sql-server-released/ba-p/3169228). ODBC driver version 18 is designed with an encryption-first approach, ensuring that utilities like sqlcmd and bcp, which utilize the Microsoft ODBC driver, operate under the secure by default principle. Users who wish to disable encryption must do so explicitly.
